### PR TITLE
PB-528: Redesign av hjelpetekst popover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dittnav-brukernotifikasjoner-intro",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://navikt.github.io/dittnav-brukernotifikasjoner-intro",
   "name": "dittnav-brukernotifikasjoner-intro",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^5.6.4",

--- a/src/App.less
+++ b/src/App.less
@@ -9,57 +9,45 @@
   text-align: center;
 }
 
-
-@coreModulePath: '../../../node_modules/';
-@nav-frontend-core: '../../node_modules/';
-
-@import '../node_modules/nav-frontend-lenker-style/src/lenker-style.less';
-@import '../node_modules/nav-frontend-typografi-style/src/index.less';
-@import '../node_modules/nav-frontend-popover-style/src/popover-style.less';
-
-.App {
-  text-align: center;
-}
-
 .hjelpetekst__ikon {
-  fill: #FF9100 !important;
+  fill: @navOransje !important;
 }
 
 .hjelpetekst__ikon:hover {
-  fill: #FF9100 !important;
+  fill: @navOransje !important;
 }
 
 .hjelpetekst__apneknapp:hover {
-  box-shadow: 0 0 0 2px #FFD399 !important;
-  background: #FFD399 !important;
+  box-shadow: 0 0 0 2px @navOransjeLighten60 !important;
+  background: @navOransjeLighten60 !important;
 }
 
 .hjelpetekst__apneknapp:focus {
   outline: 0;
-  box-shadow: 0 0 0 3px #FFD399;
+  box-shadow: 0 0 0 3px @navOransjeLighten60;
 }
 
 .hjelpetekst__apneknapp:focus {
   outline: 0;
   color: #fff;
-  background: #FFD399;
+  background: @navOransjeLighten60;
 }
 
 .hjelpetekst .popover__pil {
-  background-color: #FFD399;
+  background-color: @navOransjeLighten60;
 }
 
 .hjelpetekst .popover {
-  border: 1px solid #FF9100;
-  background-color: #FFD399;
+  border: 1px solid @navOransje;
+  background-color: @navOransjeLighten60;
 }
 
 .popover:focus {
   outline: none;
-  box-shadow: 0 0 0 3px #FF9100;
+  box-shadow: 0 0 0 3px @navOransje;
 }
 
 .hjelpetekst .popover--over .popover__pil {
-  border-right: 1px solid #FF9100;
-  border-bottom: 1px solid #FF9100;
+  border-right: 1px solid @navOransje;
+  border-bottom: 1px solid @navOransje;
 }

--- a/src/App.less
+++ b/src/App.less
@@ -8,3 +8,58 @@
 .App {
   text-align: center;
 }
+
+
+@coreModulePath: '../../../node_modules/';
+@nav-frontend-core: '../../node_modules/';
+
+@import '../node_modules/nav-frontend-lenker-style/src/lenker-style.less';
+@import '../node_modules/nav-frontend-typografi-style/src/index.less';
+@import '../node_modules/nav-frontend-popover-style/src/popover-style.less';
+
+.App {
+  text-align: center;
+}
+
+.hjelpetekst__ikon {
+  fill: #FF9100 !important;
+}
+
+.hjelpetekst__ikon:hover {
+  fill: #FF9100 !important;
+}
+
+.hjelpetekst__apneknapp:hover {
+  box-shadow: 0 0 0 2px #FFD399 !important;
+  background: #FFD399 !important;
+}
+
+.hjelpetekst__apneknapp:focus {
+  outline: 0;
+  box-shadow: 0 0 0 3px #FFD399;
+}
+
+.hjelpetekst__apneknapp:focus {
+  outline: 0;
+  color: #fff;
+  background: #FFD399;
+}
+
+.hjelpetekst .popover__pil {
+  background-color: #FFD399;
+}
+
+.hjelpetekst .popover {
+  border: 1px solid #FF9100;
+  background-color: #FFD399;
+}
+
+.popover:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px #FF9100;
+}
+
+.hjelpetekst .popover--over .popover__pil {
+  border-right: 1px solid #FF9100;
+  border-bottom: 1px solid #FF9100;
+}

--- a/src/components/Oversikt.js
+++ b/src/components/Oversikt.js
@@ -19,6 +19,7 @@ const BildeContainer = styled.div`
 
 const Forklaring = styled(Hjelpetekst)`  
   position: absolute;
+  text-align: left;
   ${props => props.top && `top: ${props.top};`}
   ${props => props.left && `left: ${props.left};`}
   
@@ -60,7 +61,8 @@ const Oversikt = () => {
             Tidslinjekomponenten viser hva som har skjedd og hva som skal skje i saken, basert på statusoppdateringer og brukernotifikasjoner.
           </Forklaring>
           <Forklaring top="85%" left="80%">
-            Innholdet i komponenten vil være generisk (basert på globale statuser) og tilpasses av teamene slik at den for eksempel også viser lokale statuser og bedre tilpasset tekstlig informasjon.          </Forklaring>
+            Innholdet i komponenten vil være generisk (basert på globale statuser) og tilpasses av teamene<br/> slik at den for eksempel også viser lokale statuser og bedre tilpasset tekstlig informasjon.
+          </Forklaring>
         </BildeContainer>
       </Innhold>
     </Layout>

--- a/src/components/Oversikt.js
+++ b/src/components/Oversikt.js
@@ -56,10 +56,10 @@ const Oversikt = () => {
           <Forklaring top="15%" left="74%">
             Tenkt eksempel på en generisk innsyn i sak-side, med saksspesifikke oppgaver/beskjeder<br/> og en tidslinjekomponent som viser hva som har skjedd og hva som skal skje i saken.
           </Forklaring>
-          <Forklaring top="75%" left="3%" type="over-hoyre">
+          <Forklaring top="75%" left="3%" type="over-venstre">
             Tidslinjekomponenten viser hva som har skjedd og hva som skal skje i saken, basert på statusoppdateringer og brukernotifikasjoner.
           </Forklaring>
-          <Forklaring top="85%" left="80%" type="over-hoyre">
+          <Forklaring top="85%" left="80%">
             Innholdet i komponenten vil være generisk (basert på globale statuser) og tilpasses av teamene slik at den for eksempel også viser lokale statuser og bedre tilpasset tekstlig informasjon.          </Forklaring>
         </BildeContainer>
       </Innhold>

--- a/src/components/Oversikt.js
+++ b/src/components/Oversikt.js
@@ -54,11 +54,13 @@ const Oversikt = () => {
         <BildeContainer>
           <Bilde src={innsyn} alt="Skjermbilde av en side til innsyn i sak"/>
           <Forklaring top="15%" left="74%">
-            Tenkt eksempel på en generisk innsyn i sak-side, med saksspesifikke oppgaver/beskjeder og en tidslinjekomponent som viser hva som har skjedd og hva som skal skje i saken.
+            Tenkt eksempel på en generisk innsyn i sak-side, med saksspesifikke oppgaver/beskjeder<br/> og en tidslinjekomponent som viser hva som har skjedd og hva som skal skje i saken.
           </Forklaring>
-          <Forklaring top="75%" left="93%" type="over-hoyre">
-            Tidslinjekomponenten viser hva som har skjedd og hva som skal skje i saken, basert på statusoppdateringer og brukernotifikasjoner. Innholdet i komponenten vil være generisk (basert på globale statuser) og tilpasses av teamene slik at den for eksempel også viser lokale statuser og bedre tilpasset tekstlig informasjon.
+          <Forklaring top="75%" left="3%" type="over-hoyre">
+            Tidslinjekomponenten viser hva som har skjedd og hva som skal skje i saken, basert på statusoppdateringer og brukernotifikasjoner.
           </Forklaring>
+          <Forklaring top="85%" left="80%" type="over-hoyre">
+            Innholdet i komponenten vil være generisk (basert på globale statuser) og tilpasses av teamene slik at den for eksempel også viser lokale statuser og bedre tilpasset tekstlig informasjon.          </Forklaring>
         </BildeContainer>
       </Innhold>
     </Layout>


### PR DESCRIPTION
* Redesignet hjelpetekst popover-en for å skille det ut fra skissene.
* Delt opp forklaringen av tidslinjen i to for å unngå for mye tekst i en popover.

PB-528: Fylle ut skisser og tekstlig forklaring